### PR TITLE
fix: update code for PyTorch 2.7

### DIFF
--- a/condenser/Condenser.py
+++ b/condenser/Condenser.py
@@ -205,12 +205,12 @@ class Condenser:
         )
         if args.sampling_net:
             scheduler_sampling_net = torch.optim.lr_scheduler.ReduceLROnPlateau(
-            optim_img, mode="min", factor=0.5, patience=500, verbose=False
+            optim_img, mode="min", factor=0.5, patience=500
         )
         else:
             scheduler_sampling_net = None
         scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
-            optim_img, mode="min", factor=0.5, patience=500, verbose=False
+            optim_img, mode="min", factor=0.5, patience=500
         )
         gather_save_visualize(self, args)
         if args.local_rank == 0:


### PR DESCRIPTION
'verbose' parameter to ReduceLROnPlateau is deprecated since PyTorch 2.2 and no longer supported in the stable release (2.7). it now causes a TypeError

The default value was False so removal should not change anything